### PR TITLE
Use "nobrl" option by default

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -10,6 +10,7 @@ local params = inv.parameters.csi_driver_smb;
 local defaultMountOptions = [
   'dir_mode=0777',
   'file_mode=0777',
+  'nobrl',
   'vers=3.0',
 ];
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,6 +7,12 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.csi_driver_smb;
 
+local defaultMountOptions = [
+  'dir_mode=0777',
+  'file_mode=0777',
+  'vers=3.0',
+];
+
 local pvs = [
   kube.PersistentVolume(pv.name) {
     spec+: {
@@ -15,7 +21,7 @@ local pvs = [
       },
       accessModes: com.getValueOrDefault(pv, 'accessModes', [ 'ReadWriteMany' ],),
       persistentVolumeReclaimPolicy: com.getValueOrDefault(pv, 'reclaimPolicy', null),
-      mountOptions: com.getValueOrDefault(pv, 'mountOptions', [ 'dir_mode=0777', 'file_mode=0777', 'vers=3.0' ]),
+      mountOptions: com.getValueOrDefault(pv, 'mountOptions', defaultMountOptions),
       csi: {
         driver: 'smb.csi.k8s.io',
         readOnly: com.getValueOrDefault(pv, 'readOnly', null),


### PR DESCRIPTION
This was requested by a customer, and based on the documentation I think it makes sense to enable this by default.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] ~Link this PR to related issues.~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
