### PR TITLE
Manage Namespace and support OpenShift

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,10 +2,12 @@ parameters:
   csi_driver_smb:
     namespace: kube-system
     charts:
-      csi-driver-smb: v1.5.0
+      csi-driver-smb: v1.7.0
     helmValues:
       serviceAccount:
-        create: false
+        create: true
+        controller: csi-smb-controller-sa
+        node: csi-smb-node-sa
 
     volumes: []
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -18,6 +18,15 @@ default:: [ 'dir_mode=0777', 'file_mode=0777', 'vers=3.0' ]
 
 Mount options to use by default.
 
+== `helmValues`
+
+[horizontal]
+type:: dict
+default:: See `class/defaults.yml`
+
+Values passed to Helm.
+See https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/README.md[Chart README] for a list of possible parameters.
+
 == `volumes`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,5 +1,8 @@
 ---
 parameters:
+  facts:
+    distribution: openshift
+
   kapitan:
     dependencies:
       - type: https
@@ -16,6 +19,10 @@ parameters:
       - file_mode=0777
       - nobrl
       - vers=3.0
+    helmValues:
+      serviceAccount:
+        controller: controller
+        node: node
     volumes:
       - name: my_share
         namespace: my-test-app

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/00_namespace.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: example-namespace
+  name: example-namespace

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/05_rolebinding.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/05_rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: privileged
+  name: privileged
+  namespace: example-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: example-namespace
+  - kind: ServiceAccount
+    name: node
+    namespace: example-namespace

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/05_serviceaccount.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/05_serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    name: csi-smb-controller-sa
-  name: csi-smb-controller-sa
-  namespace: example-namespace

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-controller.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-controller.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/instance: csi-driver-smb
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: v1.5.0
-    helm.sh/chart: csi-driver-smb-v1.5.0
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
   name: csi-smb-controller
   namespace: example-namespace
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: csi-smb-controller
@@ -21,18 +21,19 @@ spec:
         app.kubernetes.io/instance: csi-driver-smb
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: csi-driver-smb
-        app.kubernetes.io/version: v1.5.0
-        helm.sh/chart: csi-driver-smb-v1.5.0
+        app.kubernetes.io/version: v1.7.0
+        helm.sh/chart: csi-driver-smb-v1.7.0
     spec:
       containers:
         - args:
             - -v=2
             - --csi-address=$(ADDRESS)
             - --leader-election
+            - --leader-election-namespace=example-namespace
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
           resources:
@@ -49,7 +50,7 @@ spec:
             - --probe-timeout=3s
             - --health-port=29642
             - --v=2
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -70,7 +71,7 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          image: registry.k8s.io/sig-storage/smbplugin:v1.5.0
+          image: registry.k8s.io/sig-storage/smbplugin:v1.7.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5
@@ -99,17 +100,20 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
-      serviceAccountName: csi-smb-controller-sa
+      serviceAccountName: controller
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
         - effect: NoSchedule
           key: node-role.kubernetes.io/controlplane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
           operator: Exists
       volumes:
         - emptyDir: {}

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-node.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-node.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: csi-driver-smb
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: v1.5.0
-    helm.sh/chart: csi-driver-smb-v1.5.0
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
   name: csi-smb-node
   namespace: example-namespace
 spec:
@@ -20,8 +20,8 @@ spec:
         app.kubernetes.io/instance: csi-driver-smb
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: csi-driver-smb
-        app.kubernetes.io/version: v1.5.0
-        helm.sh/chart: csi-driver-smb-v1.5.0
+        app.kubernetes.io/version: v1.7.0
+        helm.sh/chart: csi-driver-smb-v1.7.0
     spec:
       containers:
         - args:
@@ -29,7 +29,7 @@ spec:
             - --probe-timeout=3s
             - --health-port=29643
             - --v=2
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -50,7 +50,7 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/smb.csi.k8s.io/csi.sock
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:
@@ -87,7 +87,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: registry.k8s.io/sig-storage/smbplugin:v1.5.0
+          image: registry.k8s.io/sig-storage/smbplugin:v1.7.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5
@@ -116,11 +116,12 @@ spec:
             - mountPath: /var/lib/kubelet/
               mountPropagation: Bidirectional
               name: mountpoint-dir
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
+      serviceAccountName: node
       tolerations:
         - operator: Exists
       volumes:

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/rbac-csi-smb.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/rbac-csi-smb.yaml
@@ -1,3 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-smb
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: csi-driver-smb
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
+  name: controller
+  namespace: example-namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-smb
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: csi-driver-smb
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
+  name: node
+  namespace: example-namespace
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -5,8 +29,8 @@ metadata:
     app.kubernetes.io/instance: csi-driver-smb
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: v1.5.0
-    helm.sh/chart: csi-driver-smb-v1.5.0
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
   name: smb-external-provisioner-role
 rules:
   - apiGroups:
@@ -88,8 +112,8 @@ metadata:
     app.kubernetes.io/instance: csi-driver-smb
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: v1.5.0
-    helm.sh/chart: csi-driver-smb-v1.5.0
+    app.kubernetes.io/version: v1.7.0
+    helm.sh/chart: csi-driver-smb-v1.7.0
   name: smb-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -97,5 +121,5 @@ roleRef:
   name: smb-external-provisioner-role
 subjects:
   - kind: ServiceAccount
-    name: csi-smb-controller-sa
+    name: controller
     namespace: example-namespace


### PR DESCRIPTION
csi-driver-smb has to be updated to v1.7.0 due to an upstream bugfix
which added the `serviceAccountName` to the node DaemonSet.
    
The Helm Chart can create the ServiceAccounts and we therefore don't
have to manage them in this component.
    
The Pods of this CSIDriver run in privileged mode and therefore require
the privileged SCC on OpenShift.

Closes #22

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
