### PR TITLE
Openshift: don't schedule pods on master nodes

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -14,8 +14,7 @@ local namespace =
   {
     metadata+: {
       annotations+: {
-        // Allow Pods to be scheduled on any Node
-        [if isOpenShift then 'openshift.io/node-selector']: '',
+        [if isOpenShift then 'openshift.io/node-selector']: 'node-role.kubernetes.io/worker=',
       },
     },
   };

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/00_namespace.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/00_namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: ''
+    openshift.io/node-selector: node-role.kubernetes.io/worker=
   labels:
     name: example-namespace
   name: example-namespace


### PR DESCRIPTION
There's no need to schedule csi driver pods on the openshift master nodes

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
