### PR TITLE
Disable emphemeral inline volume feature by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,6 +10,8 @@ parameters:
         create: true
         controller: csi-smb-controller-sa
         node: csi-smb-node-sa
+      feature:
+        enableInlineVolume: false
 
     volumes: []
 

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-driver.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/csi-smb-driver.yaml
@@ -7,4 +7,3 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
     - Persistent
-    - Ephemeral

--- a/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/rbac-csi-smb.yaml
+++ b/tests/golden/defaults/csi-driver-smb/csi-driver-smb/10_csi-driver-smb_helmchart/csi-driver-smb/templates/rbac-csi-smb.yaml
@@ -165,24 +165,6 @@ rules:
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/instance: csi-driver-smb
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: csi-driver-smb-1.20.1
-  name: csi-smb-node-secret-role
-rules:
-  - apiGroups:
-      - ''
-    resources:
-      - secrets
-    verbs:
-      - get
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -218,23 +200,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: controller
-    namespace: example-namespace
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: csi-driver-smb
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: csi-driver-smb
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: csi-driver-smb-1.20.1
-  name: csi-smb-node-secret-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: csi-smb-node-secret-role
-subjects:
-  - kind: ServiceAccount
-    name: node
     namespace: example-namespace


### PR DESCRIPTION
The latest chart csi-driver-smb  v1.20.1 can't be applied by ArgoCD because it tries to modify the `csidrivers.storage.k8s.io.spec.volumeLifecycleModes` field, which is immutable.

We disable this feature by default, so we don't have to replace existing CSI drivers.

```
kubectl explain csidrivers.storage.k8s.io.spec.volumeLifecycleModes
GROUP:      storage.k8s.io
KIND:       CSIDriver
VERSION:    v1

FIELD: volumeLifecycleModes <[]string>


DESCRIPTION:
    volumeLifecycleModes defines what kind of volumes this CSI volume driver
    supports. The default if the list is empty is "Persistent", which is the
    usage defined by the CSI specification and implemented in Kubernetes via the
    usual PV/PVC mechanism.
    
    The other mode is "Ephemeral". In this mode, volumes are defined inline
    inside the pod spec with CSIVolumeSource and their lifecycle is tied to the
    lifecycle of that pod. A driver has to be aware of this because it is only
    going to get a NodePublishVolume call for such a volume.
    
    For more information about implementing this mode, see
    https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver
    can support one or more of these modes and more modes may be added in the
    future.
    
    This field is beta. This field is immutable.
```

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
